### PR TITLE
Add `GET /sensors` route

### DIFF
--- a/server/app/constants.py
+++ b/server/app/constants.py
@@ -1,0 +1,13 @@
+import enum
+
+
+class Limit(int, enum.Enum):
+    SMALL = 2**6  # 64
+    MEDIUM = 2**8  # 256
+    LARGE = 2**10  # 1024
+    MAXINT4 = 2**31  # Maximum value signed 32-bit integer + 1
+
+
+class Pattern(str, enum.Enum):
+    SENSOR_IDENTIFIER = r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$"
+    VALUE_IDENTIFIER = r"^(?!_)(?!.*__)[a-z0-9_]{1,64}(?<!_)$"

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -65,6 +65,9 @@ MEASUREMENTS = sa.Table(
     sa.Column("value", sa.Integer, nullable=False),
 )
 
+CONF = CONFIGURATIONS
+MEAS = MEASUREMENTS
+
 VALUE_IDENTIFIERS = set(MEASUREMENTS.columns.keys()) - {
     "sensor_identifier",
     "measurement_timestamp",

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -4,8 +4,8 @@ import databases.interfaces
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql
 
-import app.settings as settings
 import app.constants as constants
+import app.settings as settings
 
 
 def dictify(result: typing.Sequence[databases.interfaces.Record]) -> typing.List[dict]:
@@ -62,6 +62,7 @@ MEASUREMENTS = sa.Table(
     ),
     sa.Column("measurement_timestamp", sa.Integer, nullable=False),
     sa.Column("receipt_timestamp", sa.Integer, nullable=False),
+    # TODO implement as JSON for maximum flexibility?
     sa.Column("value", sa.Integer, nullable=False),
 )
 

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -26,6 +26,35 @@ CONFIGURATION = {
 
 
 ########################################################################################
+# Query helpers
+########################################################################################
+
+
+def filter_sensor_identifier(conditions, request):
+    """Add conditions to constrain the returned sensor identifiers."""
+    return conditions + [
+        sa.or_(
+            MEASUREMENTS.c.sensor_identifier == sensor_identifier
+            for sensor_identifier in request.query.sensors
+        ),
+    ]
+
+
+def filter_measurement_timestamp(conditions, request):
+    """Add conditions to constrain the returned measurement timestamps."""
+    res = []
+    if request.query.start_timestamp is not None:
+        res.append(
+            MEASUREMENTS.c.measurement_timestamp >= int(request.query.start_timestamp)
+        )
+    if request.query.end_timestamp is not None:
+        res.append(
+            MEASUREMENTS.c.measurement_timestamp < int(request.query.end_timestamp)
+        )
+    return conditions + res
+
+
+########################################################################################
 # Table schemas
 ########################################################################################
 
@@ -65,9 +94,6 @@ MEASUREMENTS = sa.Table(
     # TODO implement as JSON for maximum flexibility?
     sa.Column("value", sa.Integer, nullable=False),
 )
-
-CONF = CONFIGURATIONS
-MEAS = MEASUREMENTS
 
 VALUE_IDENTIFIERS = set(MEASUREMENTS.columns.keys()) - {
     "sensor_identifier",

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -38,7 +38,7 @@ CONFIGURATIONS = sa.Table(
     "configurations",
     metadata,
     sa.Column(
-        "node_identifier",
+        "sensor_identifier",
         sa.String(length=validation.Limit.MEDIUM),
         primary_key=True,
     ),
@@ -51,10 +51,10 @@ MEASUREMENTS = sa.Table(
     "measurements",
     metadata,
     sa.Column(
-        "node_identifier",
+        "sensor_identifier",
         sa.String(length=validation.Limit.MEDIUM),
         sa.ForeignKey(
-            CONFIGURATIONS.columns.node_identifier,
+            CONFIGURATIONS.columns.sensor_identifier,
             onupdate="CASCADE",
             ondelete="CASCADE",
         ),

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -56,7 +56,7 @@ MEASUREMENTS = sa.Table(
         sa.ForeignKey(
             CONFIGURATIONS.columns.sensor_identifier,
             onupdate="CASCADE",
-            ondelete="CASCADE",
+            ondelete="CASCADE",  # cascade is so fucking sexy
         ),
         nullable=False,
     ),

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql
 
 import app.settings as settings
-import app.validation as validation
+import app.constants as constants
 
 
 def dictify(result: typing.Sequence[databases.interfaces.Record]) -> typing.List[dict]:
@@ -39,7 +39,7 @@ CONFIGURATIONS = sa.Table(
     metadata,
     sa.Column(
         "sensor_identifier",
-        sa.String(length=validation.Limit.MEDIUM),
+        sa.String(length=constants.Limit.MEDIUM),
         primary_key=True,
     ),
     sa.Column("creation_timestamp", sa.Integer, nullable=False),
@@ -52,7 +52,7 @@ MEASUREMENTS = sa.Table(
     metadata,
     sa.Column(
         "sensor_identifier",
-        sa.String(length=validation.Limit.MEDIUM),
+        sa.String(length=constants.Limit.MEDIUM),
         sa.ForeignKey(
             CONFIGURATIONS.columns.sensor_identifier,
             onupdate="CASCADE",
@@ -64,3 +64,9 @@ MEASUREMENTS = sa.Table(
     sa.Column("receipt_timestamp", sa.Integer, nullable=False),
     sa.Column("value", sa.Integer, nullable=False),
 )
+
+VALUE_IDENTIFIERS = set(MEASUREMENTS.columns.keys()) - {
+    "sensor_identifier",
+    "measurement_timestamp",
+    "receipt_timestamp",
+}

--- a/server/app/errors.py
+++ b/server/app/errors.py
@@ -13,4 +13,4 @@ class _CustomError(starlette.exceptions.HTTPException):
 
 class InvalidSyntaxError(_CustomError):
     STATUS_CODE = 400
-    DETAIL = "invalid syntax"
+    DETAIL = "Invalid syntax"

--- a/server/app/logs.py
+++ b/server/app/logs.py
@@ -1,5 +1,6 @@
 import logging
 
+
 formatter = logging.Formatter(
     fmt="{asctime} | {levelname:8} | {msg}",
     datefmt="%a %Y-%m-%d %H:%M:%S %z",

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -62,7 +62,7 @@ async def get_sensors(request):
     latest_measurements = (
         sa.select(MEAS.c)
         .select_from(MEAS)
-        .order_by(MEAS.c.sensor_identifier.asc(), MEAS.c.measurement_timestamp.asc())
+        .order_by(MEAS.c.sensor_identifier.asc(), MEAS.c.measurement_timestamp.desc())
         .distinct(MEAS.c.sensor_identifier)
     )
     query = (
@@ -71,6 +71,7 @@ async def get_sensors(request):
             CONF.join(
                 latest_measurements,
                 CONF.c.sensor_identifier == latest_measurements.c.sensor_identifier,
+                isouter=True,
             )
         )
         .where(sa.and_(*conditions))

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -43,22 +43,9 @@ async def get_status(request):
 
 async def get_sensors(request):
     """Return status and configuration of sensors."""
+    request = await validation.validate(request, validation.GetSensorsRequest)
 
     # TODO Include last seen timestamp / last measurement timestamp
-
-    try:
-        import json
-
-        body = await request.body()
-        body = {} if len(body) == 0 else json.loads(body.decode())
-
-        request = validation.GetSensorsRequest(
-            request.query_params,
-            body,
-        )
-    except (TypeError, ValueError) as e:
-        logger.warning(f"[HTTP] [GET /sensors] Invalid request: {e}")
-        raise errors.InvalidSyntaxError()
 
     conditions = []
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -3,7 +3,6 @@ import contextlib
 
 import asyncio_mqtt as aiomqtt
 import databases
-import pydantic
 import sqlalchemy as sa
 import starlette.applications
 import starlette.responses

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -86,11 +86,18 @@ async def get_sensors(request):
             FROM measurements
             WHERE measurement_timestamp >= :start
         ),
-        buckets_wd AS (
+        buckets AS (
             SELECT sensor_identifier, bucket, COUNT(*) AS count
             FROM rounded_timestamps
             GROUP BY sensor_identifier, bucket
             ORDER BY bucket ASC
+        ),
+        buckets_wd AS (
+            SELECT sensor_identifier, bucket, COALESCE(count, 0) AS count
+            FROM
+                UNNEST(ARRAY[0,1,2,3]) bucket
+                CROSS JOIN (SELECT sensor_identifier FROM buckets GROUP BY sensor_identifier) sensors
+                LEFT OUTER JOIN buckets USING (sensor_identifier, bucket)
         ),
         activity AS (
             SELECT

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -67,7 +67,11 @@ async def get_sensors(request):
 
     timestamp = utils.timestamp()
     window = 24 * 60 * 60  # We aggregate over 24 hour buckets
+
     # TODO buckets begin at UTC midnight -> maybe simply use last 24 hours?
+    # oder stuendlich aggregieren und dann auf dem frontend an die timezone anpassen
+    # oder bei request einfach die timezone mitgeben
+
     timestamps = list(range((timestamp // window - 27) * window, timestamp, window))
 
     # TODO remove

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -41,6 +41,25 @@ async def get_status(request):
     )
 
 
+async def get_nodes(request):
+    """Return status and configuration of nodes."""
+
+    # TODO Implement filtering on node_identifier and subsequent request validation
+    # TODO Include last seen timestamp / last measurement timestamp
+
+    conditions = []
+
+    result = await database_client.fetch_all(
+        query=(
+            sa.select(CONFIGURATIONS.columns)
+            .select_from(CONFIGURATIONS)
+            .where(sa.and_(*conditions))
+            .order_by(sa.asc(CONFIGURATIONS.columns.node_identifier))
+        )
+    )
+    return starlette.responses.JSONResponse(database.dictify(result))
+
+
 async def get_measurements(request):
     """Return measurements sorted chronologically, optionally filtered."""
 
@@ -144,6 +163,11 @@ app = starlette.applications.Starlette(
         starlette.routing.Route(
             path="/status",
             endpoint=get_status,
+            methods=["GET"],
+        ),
+        starlette.routing.Route(
+            path="/nodes",
+            endpoint=get_nodes,
             methods=["GET"],
         ),
         starlette.routing.Route(

--- a/server/app/mqtt.py
+++ b/server/app/mqtt.py
@@ -54,17 +54,17 @@ async def _process_measurement_payload(
             await database_client.execute(
                 query=MEASUREMENTS.insert(),
                 values={
-                    "node_identifier": measurement.node_identifier,
+                    "sensor_identifier": measurement.sensor_identifier,
                     "measurement_timestamp": measurement.timestamp,
                     "receipt_timestamp": receipt_timestamp,
                     key: value,
                 },
             )
     except (TypeError, ValueError) as e:
-        # TODO still save `node_identifier` and `receipt_timestamp` in database?
-        # -> works only if node_identifier is inferred from sender ID
-        # Like this, we can show the timestamp of last message in the node status, even
-        # if it was invalid
+        # TODO still save `sensor_identifier` and `receipt_timestamp` in database?
+        # -> works only if sensor_identifier is inferred from sender ID
+        # Like this, we can show the timestamp of last message in the sensor status,
+        # even if it was invalid
         logger.warning(f"[MQTT] [TOPIC:measurements] Invalid message: {e}")
     except Exception as e:
         # TODO log database error and rollback
@@ -77,9 +77,9 @@ async def listen_and_write(
 ) -> typing.NoReturn:
     """Listen to incoming sensor measurements and write them to the database.
 
-    - TODO Allow nodes to send measurements for only part of all values (e.g. when one
-      of multiple sensors breaks, different node architectures, etc.)
-    - TODO Use sender ID as "node" value?
+    - TODO Allow sensors to send measurements for only part of all values (e.g. when one
+      of multiple sensors breaks, different sensor architectures, etc.)
+    - TODO Use sender ID as "sensor" value?
     """
     async with mqtt_client.unfiltered_messages() as messages:
         await mqtt_client.subscribe("measurements")

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -2,6 +2,7 @@ import os
 
 import app.utils as utils
 
+
 # Check that required environment variables are set
 _VARS = [
     "COMMIT_SHA",

--- a/server/app/validation.py
+++ b/server/app/validation.py
@@ -57,7 +57,9 @@ async def validate(
 
 
 class Limit(int, enum.Enum):
-    MEDIUM = 2**6  # 64
+    SMALL = 2**6  # 64
+    MEDIUM = 2**8  # 256
+    LARGE = 2**10  # 1024
     MAXINT4 = 2**31  # Maximum value signed 32-bit integer + 1
 
 
@@ -109,8 +111,9 @@ POSITIVE_INTEGER_VALIDATOR = attrs.validators.and_(
 # Attrs fields
 ########################################################################################
 
-# We could define these with default converters and validators, and optionally
-# pass additional converters and validators than run after the default ones.
+# Maybe we can define these with default converters and validators, and optionally:
+# - pass additional converters and validators than run after the default ones
+# - pass different default values
 
 POSITIVE_INTEGER_QUERY_FIELD = attrs.field(
     default=None,
@@ -168,7 +171,16 @@ class GetMeasurementsRequestQuery(_RequestQuery):
         ),
     )
     skip: int = POSITIVE_INTEGER_QUERY_FIELD
-    limit: int = POSITIVE_INTEGER_QUERY_FIELD
+    limit: int = attrs.field(
+        default=Limit.MEDIUM,
+        converter=attrs.converters.optional(int),
+        validator=attrs.validators.optional(
+            attrs.validators.and_(
+                POSITIVE_INTEGER_VALIDATOR,
+                attrs.validators.le(Limit.LARGE),
+            )
+        ),
+    )
 
 
 @attrs.frozen

--- a/server/app/validation.py
+++ b/server/app/validation.py
@@ -108,13 +108,12 @@ POSITIVE_INTEGER_VALIDATOR = attrs.validators.and_(
 # Maybe we can define these with default converters and validators, and optionally:
 # - pass additional converters and validators than run after the default ones
 # - pass different default values
+# - automatically set converters and validators optional if default=None is set
 
 POSITIVE_INTEGER_QUERY_FIELD = attrs.field(
-    default=0,
+    default=None,
     converter=attrs.converters.optional(int),
-    validator=attrs.validators.optional(
-        attrs.validators.and_(POSITIVE_INTEGER_VALIDATOR)
-    ),
+    validator=attrs.validators.optional(POSITIVE_INTEGER_VALIDATOR),
 )
 
 
@@ -162,7 +161,7 @@ class GetMeasurementsRequestQuery(_RequestQuery):
     )
     start_timestamp: int = POSITIVE_INTEGER_QUERY_FIELD
     end_timestamp: int = attrs.field(
-        default=constants.Limit.MAXINT4 - 1,
+        default=None,
         converter=attrs.converters.optional(int),
         validator=attrs.validators.optional(
             attrs.validators.and_(
@@ -171,15 +170,17 @@ class GetMeasurementsRequestQuery(_RequestQuery):
             )
         ),
     )
-    skip: int = POSITIVE_INTEGER_QUERY_FIELD
+    skip: int = attrs.field(
+        default=0,
+        converter=int,
+        validator=POSITIVE_INTEGER_VALIDATOR,
+    )
     limit: int = attrs.field(
         default=constants.Limit.MEDIUM,
-        converter=attrs.converters.optional(int),
-        validator=attrs.validators.optional(
-            attrs.validators.and_(
-                POSITIVE_INTEGER_VALIDATOR,
-                attrs.validators.le(constants.Limit.LARGE),
-            )
+        converter=int,
+        validator=attrs.validators.and_(
+            POSITIVE_INTEGER_VALIDATOR,
+            attrs.validators.le(constants.Limit.LARGE),
         ),
     )
 

--- a/server/app/validation.py
+++ b/server/app/validation.py
@@ -4,10 +4,10 @@ import json
 import attrs
 import starlette
 
-import app.errors as errors
 import app.constants as constants
-from app.logs import logger
+import app.errors as errors
 from app.database import VALUE_IDENTIFIERS
+from app.logs import logger
 
 
 ########################################################################################

--- a/server/app/validation.py
+++ b/server/app/validation.py
@@ -1,5 +1,6 @@
 import enum
 
+import abc
 import attrs
 import pydantic
 
@@ -97,10 +98,31 @@ class Measurement:
     )
 
 
-@attrs.frozen
-class GetSensorsRequest:
+class _RequestBody:
+    pass
 
-    # TODO split into query and body
+
+class _RequestQuery:
+    pass
+
+
+class _Request(abc.ABC):
+    """Abstract class for request validation models."""
+
+    @property
+    @abc.abstractmethod
+    def query(self) -> _RequestQuery:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def body(self) -> _RequestBody:
+        pass
+
+
+@attrs.frozen
+class GetSensorsRequestQuery(_RequestQuery):
+
     # TODO make sensors query parameter optional
 
     sensors: list[str] = attrs.field(
@@ -109,4 +131,19 @@ class GetSensorsRequest:
             iterable_validator=attrs.validators.instance_of(list),
             member_validator=SENSOR_IDENTIFIER_VALIDATOR,
         ),
+    )
+
+
+@attrs.frozen
+class GetSensorsRequestBody(_RequestBody):
+    pass
+
+
+@attrs.frozen
+class GetSensorsRequest(_Request):
+    query: GetSensorsRequestQuery = attrs.field(
+        converter=lambda x: GetSensorsRequestQuery(**x),
+    )
+    body: GetSensorsRequestBody = attrs.field(
+        converter=lambda x: GetSensorsRequestBody(**x),
     )

--- a/server/app/validation.py
+++ b/server/app/validation.py
@@ -3,7 +3,6 @@ import enum
 import json
 
 import attrs
-import pydantic
 import starlette
 
 import app.errors as errors

--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -978,21 +978,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "pydantic"
-version = "1.10.2"
-description = "Data validation and settings management using python type hints"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
-
-[[package]]
 name = "Pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1391,7 +1376,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "ebe9a4f424da6e0ea2942a1a11613371905f0c884495d3b499778d88948ae4b4"
+content-hash = "59fa9f5ac0d89ef75db6652967effa221f74895f4d38b2652b68ba0f4b1db55a"
 
 [metadata.files]
 anyio = [
@@ -2081,44 +2066,6 @@ py = [
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
-]
-pydantic = [
-    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
-    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
-    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
-    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
-    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
-    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
-    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
-    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
-    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
-    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
-    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
-    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
-    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
-    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
-    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
-    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
-    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
-    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
-    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
-    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
-    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
-    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
-    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
-    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
-    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
-    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
-    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
-    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
-    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
-    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
-    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
-    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
-    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
-    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
-    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
-    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -11,7 +11,6 @@ starlette = "^0.21.0"
 uvicorn = {extras = ["standard"], version = "^0.18.3"}
 databases = {extras = ["asyncpg"], version = "^0.6.1"}
 SQLAlchemy = {extras = ["mypy"], version = "^1.4.42"}
-pydantic = "^1.10.2"
 asyncio-mqtt = "^0.13.0"
 attrs = "^22.1.0"
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -21,6 +21,19 @@ isort = "^5.10.1"
 black = "^22.10.0"
 docformatter = "^1.5.0"
 
+[tool.black]
+preview = true
+
+[tool.isort]
+profile = "black"
+lines_after_imports = 2
+
+[tool.docformatter]
+in-place = true
+recursive = true
+wrap-summaries = 87
+wrap-descriptions = 87
+
 [tool.mypy]
 show_error_codes = true
 no_implicit_optional = true

--- a/server/scripts/pre-commit
+++ b/server/scripts/pre-commit
@@ -6,19 +6,19 @@ GREEN='\033[01;32m'
 
 printf "[..] Running black"
 # Capture program output in variable
-output=$(script -q /dev/null poetry run black --quiet --preview ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
+output=$(script -q /dev/null poetry run black --quiet ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
 printf "\r${GREEN}[OK]${RESTORE} Running black\n"
 # If there's output, print it
 [ -z "$output" ] || echo "\n$output\n"
 
-printf "[..] Running docformatter"
-output=$(script -q /dev/null poetry run docformatter --in-place -r --wrap-summaries 87 --wrap-descriptions 87 ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
-printf "\r${GREEN}[OK]${RESTORE} Running docformatter\n"
+printf "[..] Running isort"
+output=$(script -q /dev/null poetry run isort ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
+printf "\r${GREEN}[OK]${RESTORE} Running isort\n"
 [ -z "$output" ] || echo "\n$output\n"
 
-printf "[..] Running isort"
-output=$(script -q /dev/null poetry run isort --profile black ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
-printf "\r${GREEN}[OK]${RESTORE} Running isort\n"
+printf "[..] Running docformatter"
+output=$(script -q /dev/null poetry run docformatter ./app 2>&1 | tr -d '\r' | cat | sed 's/^/  /')
+printf "\r${GREEN}[OK]${RESTORE} Running docformatter\n"
 [ -z "$output" ] || echo "\n$output\n"
 
 printf "[..] Running mypy"


### PR DESCRIPTION
This adds a new `GET /sensors` route that returns the sensor configurations, together with the timestamp of the last measurement. In the future, the underlying database query can be extended to aggregate and return some more things, like an activity timeline (see #9) or sensor health updates.

(typing is a mess still 😕)